### PR TITLE
Fix Issues with IAM Policy and Go Runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: build clean deploy
 
 build:
-		GOOS=linux GOARCH=amd64 go build -v -ldflags '-d -s -w' -a -tags netgo -installsuffix netgo -o build/bin/app main.go
-
+	GOARCH=arm64 GOOS=linux go build -tags lambda.norpc -o ./build/bin/bootstrap
+	(cd build/bin && zip -FS bootstrap.zip bootstrap)
 clean:
 	rm -rf ./build
 
@@ -13,7 +13,7 @@ plan:
 	terraform plan
 
 apply:
-	terraform apply --auto-approve
+	terraform apply
 
 destroy:
-	terraform destroy --auto-approve
+	terraform destroy

--- a/lambda.tf
+++ b/lambda.tf
@@ -1,11 +1,12 @@
 resource "aws_lambda_function" "lambda_func" {
   filename         = data.archive_file.lambda_zip.output_path
   function_name    = local.app_id
-  handler          = "app"
+  handler          = "bootstrap"
   source_code_hash = base64sha256(data.archive_file.lambda_zip.output_path)
-  runtime          = "go1.x"
+  runtime          = "provided.al2"
   role             = aws_iam_role.lambda_exec.arn
   timeout = 30
+  architectures = ["arm64"]
 #  memory_size = 1024
   environment {
     variables = {
@@ -22,7 +23,7 @@ resource "aws_lambda_function" "lambda_func" {
 #      DD_LOG_LEVEL = "debug"
     }
   }
-  layers = ["arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension:37"]
+  layers = ["arn:aws:lambda:us-west-2:464622532012:layer:Datadog-Extension-ARM:56"]
 }
 
 # Assume role setup
@@ -57,9 +58,8 @@ variable "iam_policy_arn" {
   ]
 }
 
-resource "aws_iam_policy_attachment" "role_attach" {
-  name       = "policy-${local.app_id}"
-  roles      = [aws_iam_role.lambda_exec.id]
+resource "aws_iam_role_policy_attachment" "role_attach" {
+  role      = aws_iam_role.lambda_exec.id
   count      = length(var.iam_policy_arn)
   policy_arn = element(var.iam_policy_arn, count.index)
 }

--- a/main.tf
+++ b/main.tf
@@ -29,8 +29,8 @@ locals {
 
 data "archive_file" "lambda_zip" {
   type        = "zip"
-  source_file = "build/bin/app"
-  output_path = "build/bin/app.zip"
+  source_file = "build/bin/bootstrap"
+  output_path = "build/bin/bootstrap.zip"
 }
 
 resource "random_id" "unique_suffix" {


### PR DESCRIPTION
* Use `aws_iam_role_policy_attachment` instead of `aws_iam_policy_attachment` to avoid other roles having their policies detached
  * https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment
* Use `provided.al2` runtime since `go1.x` is deprecated as of the end of 2023
  * https://aws.amazon.com/blogs/compute/migrating-aws-lambda-functions-from-the-go1-x-runtime-to-the-custom-runtime-on-amazon-linux-2/
* Build a `bootstrap` executable which is necessary for the `provided.al2` runtime
* Remove `--auto-approve` from `apply` and `destroy` commands so it's clear what's being updated
* Update Lambda architecture to `arm64`

<img width="689" alt="Screenshot 2024-04-09 at 11 03 20 AM" src="https://github.com/DataDog/datadog-lambda-go-terraform-reference-implementation/assets/35278470/ada8923b-699b-4cea-b9a3-c9264f612c2d">
